### PR TITLE
feat: allow external URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ CLOUDINARY_AUTO_MAPPING_FOLDER=xxx
 CLOUDINARY_URL=cloudinary://xxx:xxx@xxx
 ```
 
+#### 3.1. Using an External URL
+
+If your assets are served through an external URL, you need to set an additional configuration option, either in the `cloudinary.php` config file:
+
+```php
+<?php
+
+return [
+  // ...
+  'external_url_prefix' => env('CLOUDINARY_EXTERNAL_URL_PREFIX', 'https://my-external-asset-url.com'),
+];
+```
+
+... or in the `.env` file:
+
+```bash
+CLOUDINARY_EXTERNAL_URL_PREFIX=https://my-external-asset-url.com
+```
+
+For example, if you are using DigitalOcean Spaces storage and your assets are served from this URL:  
+`https://my-project.us1.digitaloceanspaces.com/website/image.jpg`, the external URL consists of two parts:
+- `https://my-project.us1.digitaloceanspaces.com` - The DigitalOcean base URL
+- `/website` - The root folder in DigitalOcean
+
+The actual value you need to set in the config or .env file would be:  
+`CLOUDINARY_EXTERNAL_URL_PREFIX=https://my-project.us1.digitaloceanspaces.com/website/`
+
 ### 4. Use the cloudinary tag
 
 You are now ready to use the cloudinary tag inside your views.

--- a/config/cloudinary.php
+++ b/config/cloudinary.php
@@ -8,6 +8,8 @@ return [
 
     'auto_mapping_folder' => env('CLOUDINARY_AUTO_MAPPING_FOLDER', ''),
 
+    'external_url_prefix' => env('CLOUDINARY_EXTERNAL_URL_PREFIX', ''),
+
     'api_key' => env('CLOUDINARY_API_KEY', ''),
 
     'api_secret' => env('CLOUDINARY_API_SECRET', ''),

--- a/src/Converter/CloudinaryConverter.php
+++ b/src/Converter/CloudinaryConverter.php
@@ -101,6 +101,7 @@ class CloudinaryConverter
             'notification_url' => config('statamic.cloudinary.notification_url'),
             'cloudinary_url' => config('statamic.cloudinary.url'),
             'cloudinary_delivery_type' => config('statamic.cloudinary.delivery_type'),
+            'external_url_prefix' => config('statamic.cloudinary.external_url_prefix'),
         ]);
     }
 
@@ -373,6 +374,10 @@ class CloudinaryConverter
         }
 
         $item = Str::ensureLeft(Str::removeLeft($item, '/'), $this->configuration->get('auto_mapping_folder'));
+
+        if ($this->configuration->get('external_url_prefix')) {
+            $item = Str::replace(Str::ensureRight($this->configuration->get('external_url_prefix'), '/'), '', $item);
+        }
 
         return $item;
     }


### PR DESCRIPTION
This PR allows the use of external URLs inside the cloudinary addon.

The assets could be served through an external URL, e. g. through DigitalOcean Spaces. For this case, a new configuration option `CLOUDINARY_EXTERNAL_URL_PREFIX` has been added. If defined, this prefix will be removed from the generated cloudinary URL.