### PR TITLE
Fix: Ensure $item is an Asset before getting original aspect ratio

### DIFF
--- a/src/Converter/CloudinaryConverter.php
+++ b/src/Converter/CloudinaryConverter.php
@@ -341,6 +341,7 @@ class CloudinaryConverter
 
     public function getFinalDimensions($item)
     {
+        $item = $this->getAsset($item);
         $width = (int) $this->getManipulationParams()->get('width');
         $height = (int) $this->getManipulationParams()->get('height');
         $aspect_ratio =


### PR DESCRIPTION
Fixes a bug where a String (like a path) passed into the `wildcard` function would result in a type error. 

This was caused by the `getOriginalAspectRatio` call in `getFinalDimensions` because `$item` is never converted to an `AssetsAsset` (via `getAsset()`).

Another way to fix this would be to ensure `$item` is an `AssetsAsset` before this point, but this fix is more consistent with the code in `generateCloudinaryUrl`.